### PR TITLE
#81: added mp3fix

### DIFF
--- a/mp3fix/README.md
+++ b/mp3fix/README.md
@@ -1,0 +1,14 @@
+### Author 
+Riccardo Tasso 
+
+#### Description
+
+mp3fix iterates through all files with the .mp3 extension within the current directory.
+
+If the file name begins with a one-digit number that is not preceded by zero, rename the file to meet this standard.
+
+#### How to use
+
+```
+python2 mp3fix.py mp3folder/
+```

--- a/mp3fix/mp3fix.py
+++ b/mp3fix/mp3fix.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import re
+import os
+
+p = re.compile(r'^\d\D.*?[.]mp3$')
+
+def main():
+    path = sys.argv[1]
+
+    for file in os.listdir(path):
+        print file
+        m = p.match(file)
+        if m:
+            old_file = os.path.join(path, file)
+            new_file = os.path.join(path, "0" + file)
+            #raw_input(old_file + " " + new_file)
+            os.rename(old_file, new_file)
+            
+
+if __name__ == "__main__":
+	sys.exit(main())


### PR DESCRIPTION
mp3fix iterates through all files with the .mp3 extension within the current directory.

If the file name begins with a one-digit number that is not preceded by zero, rename the file to meet this standard.