### PR TITLE
Fix prefix handling in bulk file renamer

### DIFF
--- a/Bulk File Renamer/README.md
+++ b/Bulk File Renamer/README.md
@@ -13,3 +13,9 @@ A simple Python script that allows you to rename multiple files in a directory b
    ```
 
 4. Follow the onscreen prompts.
+
+## Example
+
+If the selected folder contains `image.jpg` and you enter `holiday` as the base file name,
+the script renames it to `holiday_image.jpg`. When a target file already exists, a numeric
+suffix is added, such as `holiday_image_1.jpg`, so existing files are not overwritten.

--- a/Bulk File Renamer/main.py
+++ b/Bulk File Renamer/main.py
@@ -1,6 +1,31 @@
 """Bulk File Renamer
 A simple script to bulk rename files in a directory by adding a base filename as a prefix."""
 import os
+from pathlib import Path
+
+
+def build_new_name(file_path, prefix):
+    """Build the renamed file name while preserving the original extension."""
+    if file_path.name.startswith(prefix):
+        return file_path.name
+    return f"{prefix}{file_path.name}"
+
+
+def unique_destination(file_path, new_name):
+    """Return a destination path that does not overwrite an existing file."""
+    destination = file_path.with_name(new_name)
+    if not destination.exists() or destination == file_path:
+        return destination
+
+    stem = destination.stem
+    suffix = destination.suffix
+    counter = 1
+    while True:
+        candidate = destination.with_name(f"{stem}_{counter}{suffix}")
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
 
 def main():
     """Main function to execute the bulk file renaming process."""
@@ -8,15 +33,31 @@ def main():
 Leave blank for current working directory: ")
     if not rootdir:
         rootdir = os.getcwd()
-    print(f"{rootdir} selected")
+
+    root_path = Path(rootdir).expanduser().resolve()
+    if not root_path.is_dir():
+        print(f"{root_path} is not a valid directory.")
+        return
+
+    print(f"{root_path} selected")
 
     base_filename = input("Input base file name to use for renaming: \
-Leaving blank will result in an underscore being used as the prefix: ")
+Leaving blank will result in an underscore being used as the prefix: ").strip()
+    prefix = f"{base_filename}_" if base_filename else "_"
 
-    for root, _, files in os.walk(rootdir):
+    for root, _, files in os.walk(root_path):
         for file in files:
-            print(file)
-            print(f"{file} renamed to {(base_filename + '' if not base_filename else '_') + file}")
-            os.rename(os.path.join(root, file), \
-                os.path.join(root, (base_filename + "" if not base_filename else "_") + file))
-main()
+            file_path = Path(root) / file
+            new_name = build_new_name(file_path, prefix)
+            destination = unique_destination(file_path, new_name)
+
+            if destination == file_path:
+                print(f"{file_path.name} already has the prefix; skipped")
+                continue
+
+            print(f"{file_path.name} renamed to {destination.name}")
+            file_path.rename(destination)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR fixes the prefix handling logic in `Bulk File Renamer`.

Previously, when a user entered a base filename such as `photo`, the program generated renamed files like `_a.txt` instead of the expected `photo_a.txt`. This happened because the conditional expression did not correctly use the user-provided prefix.

## Changes

- Fixed the filename prefix generation logic.
- When a base filename is provided, files are renamed using the format `prefix_originalName`.
- When no base filename is provided, the existing underscore prefix behavior is preserved.
- Improved the renaming logic to make the behavior clearer and easier to maintain.

## Testing

Tested locally with sample files:

- `a.txt`
- `b.txt`
- `c.jpg`

Using `photo` as the base filename, the files are renamed as expected:

- `a.txt` -> `photo_a.txt`
- `b.txt` -> `photo_b.txt`
- `c.jpg` -> `photo_c.jpg`